### PR TITLE
Add check for empty list edge cases in sequencing algo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,12 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# macOS file system
+.DS_Store
+*/.DS_Store
+
+data/
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/README.md
+++ b/README.md
@@ -115,18 +115,18 @@ Development of software for the alignment of images in the Pando Photographic Su
 
 This pipeline is designed to run on Unix infrastructure; it will work natively on macOS and Linux, but Windows users should install Windows Subsystem for Linux. You will need the following command-line tools installed:
 
-- [ ] exiftools
-- [ ] conda
-- [ ] grip (if editing markdown files) 
+- [ ] `exiftool`
+- [ ] `conda` (See install docs [here](https://docs.anaconda.com/miniconda/install/#quick-command-line-install), select the version for your OS)
+- [ ] `grip` (if editing markdown files)
 
 ### Installation
 
 #### macOS
 
 1. Ensure the above command-line tools are installed (e.g., using `homebrew`).
-2. Create a `conda` environment for your Pando tools with
+2. Create a conda environment using Python 3.12.3 for your Pando tools with
 ```
-conda create --name pando
+conda create --name pando python=3.12.3
 ```
 3. Activate the environment with 
 ```

--- a/file_io.py
+++ b/file_io.py
@@ -13,10 +13,11 @@ import os
 import glob
 import subprocess
 import tkinter as tk
+from typing import List
 from tqdm import tqdm
 from datetime import datetime
 from tkinter import filedialog
-
+from pathlib import Path
 from orientation import Point
 
 
@@ -108,6 +109,37 @@ def get_image_dir_fpath():
 def get_config_filepath():
     return _window_management_helper.pick_file()
 
+def fix_file_names(dir_names: List[str]):
+    """
+    Iterates through files in directories and replaces whitespace with underscores.
+
+    **Args**:
+        dir_names (list[str]): List of paths to directories containing files to rename
+
+    **Returns**:
+        None
+    """
+    for dir_name in dir_names:
+        dir_path = Path(dir_name)
+
+        if not dir_path.exists():
+            bcolors.warning(f"Directory does not exist: {dir_name}")
+            continue
+
+        # Get all files in directory
+        for file_path in dir_path.glob('*'):
+            if file_path.is_file():
+                # Get original filename
+                old_name = file_path.name
+                # Replace whitespace with underscore
+                new_name = '_'.join(old_name.split())
+                # Replace multiple underscores with single underscore
+                while '__' in new_name:
+                    new_name = new_name.replace('__', '_')
+
+                # Only rename if name would change
+                if old_name != new_name:
+                    file_path.rename(dir_path / new_name)
 
 def load_points(jpg_dir, dng_dir):
     """
@@ -132,38 +164,47 @@ def load_points(jpg_dir, dng_dir):
     start_index = 0
     end_index   = 0
 
+    fix_file_names([jpg_dir, dng_dir])
+
     dngs        = sorted(glob.glob(dng_dir+"/*.dng"))
+    jpgs        = sorted(glob.glob(jpg_dir+"/*.jpg"))
 
-    for i, _im_fpath in enumerate(tqdm(sorted(glob.glob(jpg_dir+"/*.jpg")))):
+    if len(jpgs) != len(dngs):
+        bcolors.failure(f"Mismatch in number of files: {len(jpgs)} JPGs vs {len(dngs)} DNGs")
+        return None
 
-        ## locate corresponding DNG ##
-        tag = Point.get_tag(_im_fpath)
-        _dng_path = dng_dir + "/" + tag + ".dng"
+    for i, _im_fpath in enumerate(tqdm(jpgs)):
+        try:
+            ## locate corresponding DNG ##
+            tag = Point.get_tag(_im_fpath)
+            # _dng_path = next(dng for dng in dngs if dng.name == f"{tag}.dng")
+            _dng_path = dng_dir + "/" + tag + ".dng"
 
-        ## get corrupted timestamp ##
-        timestamp = subprocess.check_output(f'exiftool -v "{dngs[i]}" | grep ModifyDate', shell=True).decode("utf-8").split('15)')[-1].split('\n')[0].split('=')[-1].split(' ')[-1]
+            ## get corrupted timestamp ##
+            timestamp = subprocess.check_output(f'exiftool -v "{dngs[i]}" | grep ModifyDate', shell=True).decode("utf-8").split('15)')[-1].split('\n')[0].split('=')[-1].split(' ')[-1]
 
-        timestamp = datetime.strptime(timestamp,  '%H:%M:%S')
+            timestamp = datetime.strptime(timestamp,  '%H:%M:%S')
 
-        ## check for end slate ##
-        if 'end' in _im_fpath.lower():
-            print("Found end slate.")
-            print(timestamp)
-            points.append(Point(timestamp, _im_fpath, 'end', None, _dng_path))
-            end_index = i
+            ## check for end slate ##
+            if 'end' in _im_fpath.lower():
+                print(f"Found end slate at {timestamp}.")
+                points.append(Point(timestamp, _im_fpath, 'end', None, _dng_path))
+                end_index = i
+                continue
+
+            ## check for open slate ##
+            if 'open' in _im_fpath.lower():
+                print(f"Found open slate at {timestamp}.")
+                points.append(Point(timestamp, _im_fpath, 'open', None, _dng_path))
+                start_index = i
+                continue
+
+            points.append(Point(timestamp, _im_fpath, None, None, _dng_path))
+        except IndexError:
+            bcolors.failure(f"Failed to process file pair {i}: JPG exists but no matching DNG")
             continue
 
-        ## check for open slate ##
-        if 'open' in _im_fpath.lower():
-            print("Found open slate.")
-            print(timestamp)
-            points.append(Point(timestamp, _im_fpath, 'open', None, _dng_path))
-            start_index = i
-            continue
-
-        points.append(Point(timestamp, _im_fpath, None, None, _dng_path))
-
-    return {'points':points, 'start':start_index, 'end':end_index}
+    return {'points': points, 'start': start_index, 'end': end_index}
 
 
 

--- a/file_io.py
+++ b/file_io.py
@@ -11,6 +11,7 @@ Notes
 #------------- IMPORTS -------------#
 import os
 import glob
+import shutil
 import subprocess
 import tkinter as tk
 from typing import List
@@ -18,7 +19,7 @@ from tqdm import tqdm
 from datetime import datetime
 from tkinter import filedialog
 from pathlib import Path
-from orientation import Point
+from point import Point
 
 
 
@@ -105,6 +106,13 @@ def get_image_dir_fpath():
 
     return _window_management_helper.pick_folder()
 
+def reset_output_dir(output_dir: str):
+    if os.path.exists(output_dir):
+        shutil.rmtree(output_dir)
+
+    os.mkdir(output_dir)
+    os.mkdir(f'{output_dir}/jpgs')
+    os.mkdir(f'{output_dir}/dngs')
 
 def get_config_filepath():
     return _window_management_helper.pick_file()
@@ -140,6 +148,11 @@ def fix_file_names(dir_names: List[str]):
                 # Only rename if name would change
                 if old_name != new_name:
                     file_path.rename(dir_path / new_name)
+
+def get_timestamp(file: str):
+    timestamp = subprocess.check_output(f'exiftool -v "{file}" | grep ModifyDate', shell=True).decode("utf-8").split('15)')[-1].split('\n')[0].split('=')[-1].split(' ')[-1]
+    timestamp = datetime.strptime(timestamp,  '%H:%M:%S')
+    return timestamp
 
 def load_points(jpg_dir, dng_dir):
     """
@@ -181,9 +194,7 @@ def load_points(jpg_dir, dng_dir):
             _dng_path = dng_dir + "/" + tag + ".dng"
 
             ## get corrupted timestamp ##
-            timestamp = subprocess.check_output(f'exiftool -v "{dngs[i]}" | grep ModifyDate', shell=True).decode("utf-8").split('15)')[-1].split('\n')[0].split('=')[-1].split(' ')[-1]
-
-            timestamp = datetime.strptime(timestamp,  '%H:%M:%S')
+            timestamp = get_timestamp(dngs[i])
 
             ## check for end slate ##
             if 'end' in _im_fpath.lower():

--- a/file_io.py
+++ b/file_io.py
@@ -10,9 +10,9 @@ Notes
  
 #------------- IMPORTS -------------#
 import os
+import exiftool
 import glob
 import shutil
-import subprocess
 import tkinter as tk
 from typing import List
 from tqdm import tqdm
@@ -150,9 +150,10 @@ def fix_file_names(dir_names: List[str]):
                     file_path.rename(dir_path / new_name)
 
 def get_timestamp(file: str):
-    timestamp = subprocess.check_output(f'exiftool -v "{file}" | grep ModifyDate', shell=True).decode("utf-8").split('15)')[-1].split('\n')[0].split('=')[-1].split(' ')[-1]
-    timestamp = datetime.strptime(timestamp,  '%H:%M:%S')
-    return timestamp
+    with exiftool.ExifToolHelper() as et:
+        metadata = et.get_metadata(file)
+        modify_date_hms = metadata[0]['EXIF:ModifyDate'].split()[-1]
+        return datetime.strptime(modify_date_hms,  '%H:%M:%S')
 
 def load_points(jpg_dir, dng_dir):
     """

--- a/orientation.py
+++ b/orientation.py
@@ -13,8 +13,8 @@ import os
 import copy
 import numpy as np
 import datetime as dt
+import shutil
 from tqdm import tqdm
-
 
 
 #------------- classes -------------#
@@ -109,19 +109,32 @@ def statistical_sequence(points, start_index, end_index, output_path):
 
     #------------- sort definitive images -------------#
     for p, point in enumerate(points):
+        if point.timestamp == points[start_index].timestamp or point.timestamp == points[end_index].timestamp:
+            continue
 
         if point.timestamp < points[start_index].timestamp:
             second_half_bin.append(point)
         elif point.timestamp > points[end_index].timestamp:
             first_half_bin.append(point)
-
-        elif point.timestamp == points[start_index].timestamp or point.timestamp == points[end_index].timestamp:
-            continue
-
         else:
             points_replace.append(point)
 
+    total_sorted = len(points_replace) + len(first_half_bin) + len(second_half_bin)
+    expected_total = len(points) - 2  # subtract 2 for start/end slates
+    if total_sorted < expected_total:
+        print(f"Warning: {expected_total - total_sorted} points were excluded from sorting")
 
+    if len(first_half_bin) == 0:
+        # If no points are later than end slate, initialize first_half_bin
+        # with points that are closest to the end slate timestamp
+        first_half_bin = points_replace[-len(points_replace)//2:]
+        points_replace = points_replace[:-len(points_replace)//2]
+
+    if len(second_half_bin) == 0:
+        # If no points are earlier than start slate, initialize second_half_bin
+        # with points that are closest to the start slate timestamp
+        second_half_bin = points_replace[:len(points_replace)//2]
+        points_replace = points_replace[len(points_replace)//2:]
 
 
     #------------- build model for each -------------#
@@ -232,13 +245,12 @@ def statistical_sequence(points, start_index, end_index, output_path):
         pointcopy.timestamp = time_plus(sh_start_time, time_elapsed_bad_start)
         new_points.append(pointcopy)
 
-
-
-
-
     for p, point in enumerate(tqdm(new_points)):
-        os.system(f"cp '{point.fpath}' {output_path}/jpgs/{p}_{point.tag}_{p}_new-time={str(point.timestamp).replace(' ', '_')}.jpg")
-        os.system(f"cp '{point.dng}' {output_path}/dngs/{p}_{point.tag}_{p}_new-time={str(point.timestamp).replace(' ', '_')}.dng")
+        dst_jpg = f"{output_path}/jpgs/{p}_{point.tag}_{p}_new-time={str(point.timestamp).replace(' ', '_')}.jpg"
+        dst_dng = f"{output_path}/dngs/{p}_{point.tag}_{p}_new-time={str(point.timestamp).replace(' ', '_')}.dng"
+
+        shutil.copy2(point.fpath, dst_jpg)
+        shutil.copy2(point.dng, dst_dng)
 
     print(f"END SLATE: {end_time}. Predicted from merge: {new_points[-1].timestamp}")
 

--- a/orientation.py
+++ b/orientation.py
@@ -14,67 +14,8 @@ import copy
 import numpy as np
 import datetime as dt
 import shutil
+from file_io import reset_output_dir
 from tqdm import tqdm
-
-
-#------------- classes -------------#
-class Point(object):
-    """
-    Object for manipulating and sequencing images taken on PPS route.
-    """
-
-    def __init__(self, timestamp, fpath: str, slate, im, dng: str):
-
-        self.timestamp = timestamp
-        """Timestamp corresponding to image."""
-        self.fpath = fpath
-        """Folderpath to JPG version of image."""
-        self.dng = dng
-        """Folderpath to DNG version of image."""
-        self.slate = slate
-        """Open or end slate or None."""
-        self.im = im
-        """Image contents."""
-        self.tag = self.fpath.split('/')[-1].split('.')[0]
-        """Tag containing information assigned by Friends of Pando."""
-        self.timestamp_old = timestamp
-        """Backup version of timestamp to preserve."""
-
-    def __sub__(self, other):
-        """
-            Overwrite subtraction method to perform timestamp subtraction
-        
-            **Args**:
-        
-            * other (Point): additional Point object to perform delta.
-        
-            **Returns**:
-        
-            * delta (float): time delta between two Point objects in seconds.
-        
-        """
-         
-        
-        diff = self.timestamp - other.timestamp
-        return diff.seconds
-
-    @staticmethod
-    def get_tag(path: str):
-        """
-            Extract tag containing information assigned by Friends of Pando.
-        
-            **Args**:
-        
-            * path (str): filepath to image.
-        
-            **Returns**:
-        
-            * tag (str): tag of image.
-        
-        """
-         
-        
-        return path.split('/')[-1].split('.')[0]
 
 
 #------------- functions -------------#
@@ -365,17 +306,14 @@ def suggest_reordering(points, first_half_bin, second_half_bin, output_path, sta
         pointcopy.timestamp = time_plus(sh_start_time, time_elapsed_bad_start)
         new_points.append(pointcopy)
 
-
-
-
-    os.system(f"rm -rf {output_path}")
-    os.system(f"mkdir {output_path}")
-    os.system(f"mkdir {output_path}/jpgs/")
-    os.system(f"mkdir {output_path}/dngs/")
+    reset_output_dir(output_path)
 
     for p, point in enumerate(tqdm(new_points)):
-        os.system(f"cp '{point.fpath}' {output_path}/jpgs/{p}_{point.tag}_{p}_new-time={str(point.timestamp).replace(' ', '_')}.jpg")
-        os.system(f"cp '{point.dng}' {output_path}/dngs/{p}_{point.tag}_{p}_new-time={str(point.timestamp).replace(' ', '_')}.dng")
+        dst_jpg = f"{output_path}/jpgs/{p}_{point.tag}_{p}_new-time={str(point.timestamp).replace(' ', '_')}.jpg"
+        dst_dng = f"{output_path}/dngs/{p}_{point.tag}_{p}_new-time={str(point.timestamp).replace(' ', '_')}.dng"
+
+        shutil.copy2(point.fpath, dst_jpg)
+        shutil.copy2(point.dng, dst_dng)
 
 
     print(f"END SLATE: {end_time}. Predicted from merge: {new_points[-1].timestamp}")

--- a/pipeline.py
+++ b/pipeline.py
@@ -15,7 +15,9 @@ import sys
 import dill
 import typing_filter
 import file_io
+import shutil
 import PandoRoll
+from file_io import reset_output_dir
 from orientation import statistical_sequence, suggest_reordering
 
 
@@ -296,10 +298,8 @@ class Redirector(object):
         """
         output_fpath = file_io.get_image_dir_fpath()
         self.settings['output_dir'] = output_fpath
-        os.system(f"rm -rf {output_fpath}")
-        os.system(f"mkdir {output_fpath}")
-        os.system(f"mkdir {output_fpath}/jpgs/")
-        os.system(f"mkdir {output_fpath}/dngs/")
+        reset_output_dir(output_fpath)
+
         input(f"Created new directory at {output_fpath}. Press any key to continue.")
         return output_fpath
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -13,19 +13,10 @@ Notes
 import os
 import sys
 import dill
-import glob 
-import copy
-import subprocess
-import numpy as np
 import typing_filter
-from tqdm import tqdm 
-import datetime as dt
-from datetime import datetime
-import matplotlib.pyplot as plt
-
 import file_io
 import PandoRoll
-from orientation import Point, statistical_sequence, suggest_reordering
+from orientation import statistical_sequence, suggest_reordering
 
 
 #------------- GLOBAL SETTINGS -------------#
@@ -64,6 +55,7 @@ class Redirector(object):
     """
 
     def __init__(self):
+        self.loaded_config_file = None
         self.options: list = [
             'Quit', 
             'Load configuration',
@@ -92,29 +84,30 @@ class Redirector(object):
         """Descriptions for main menu items."""
         self.options_dict: dict = {
             'Quit':self.__quit, 
-            'Load configuration':self.__load_config, 
-            'View configuration':self.__print_settings, 
-            'Input JPG':self.__choose_input_fpath_jpg,
-            'Input DNG':self.__choose_input_fpath_dng,
-            'Output dir':self.__choose_output_fpath_dir,
-            'Load images':self.__load_images,
-            'Statistical sort':self.__stat_sort,
-            'PandoRoll':self.__center_sun,
-            'Mark bad images':self.__mark_bad,
+            'Load configuration': self.__load_config,
+            'View configuration': self.__print_settings,
+            'Input JPG': self.__choose_input_fpath_jpg,
+            'Input DNG': self.__choose_input_fpath_dng,
+            'Output dir': self.__choose_output_fpath_dir,
+            'Load images': self.__load_images,
+            'Statistical sort': self.__stat_sort,
+            'PandoRoll': self.__center_sun,
+            'Mark bad images': self.__mark_bad,
         }
         """Switchboard; input from `self.options` converts to pipeline functionality"""
         self.settings = {
-            'Pando':True,
-            'im_fpath_JPG':None,
-            'im_fpath_DNG':None,
-            'output_dir':None,
-            'start_index':None,
-            'end_index':None,
-            'points':None,
-            'fh_bin':None,
-            'sh_bin':None,
-            'bad_images':None,
-            'final_list':None,
+            'Pando': True,
+            'im_fpath_JPG': None,
+            'im_fpath_DNG': None,
+            'output_dir': None,
+            'start_index': None,
+            'end_index': None,
+            'points': None,
+            'fh_bin': None,
+            'sh_bin': None,
+            'bad_images': None,
+            'final_list': None,
+            'diffs_combined_mean': None,
         }
         """Settings for current pipeline configuration; saved after each operation"""
 
@@ -138,7 +131,10 @@ class Redirector(object):
         with open("config.pando", "wb") as f:
             dill.dump(self.settings, f)
 
-    def __load_config(self):
+    def autoload_config(self, filename: str):
+        self.__load_config(input_fpath=filename)
+
+    def __load_config(self, input_fpath=None):
         """
             Load pipeline configuration from `.pando` file and 
             imports into `self.settings`.
@@ -153,12 +149,14 @@ class Redirector(object):
         
         """
         
-        input_fpath = file_io.get_config_filepath()
+        if input_fpath is None:
+            input_fpath = file_io.get_config_filepath()
 
         with open(input_fpath, "rb") as f:
             self.settings = dill.load(f)
-        bcolors.success("Settings loaded.")
 
+        self.loaded_config_file = input_fpath
+        bcolors.success(f"Loaded {input_fpath}.")
         self.__print_settings()
 
     def get_options(self):
@@ -382,7 +380,15 @@ class Redirector(object):
         """
          
         
-        first_half_bin, second_half_bin, new_points, bad_images = suggest_reordering(self.settings['points'], self.settings['fh_bin'], self.settings['sh_bin'], self.settings['output_dir'], self.settings['start_index'], self.settings['end_index'], self.settings['diffs_combined_mean'])
+        first_half_bin, second_half_bin, new_points, bad_images = suggest_reordering(
+            self.settings['points'],
+            self.settings['fh_bin'],
+            self.settings['sh_bin'],
+            self.settings['output_dir'],
+            self.settings['start_index'],
+            self.settings['end_index'],
+            self.settings['diffs_combined_mean']
+        )
 
         self.settings['fh_bin'] = first_half_bin
         self.settings['sh_bin'] = second_half_bin
@@ -416,6 +422,10 @@ def main(intro=False):
         ## create RedirectorObject for settings and choices ##
         RedirectorObject = Redirector()
 
+    default_config_file = "config.pando"
+    if not RedirectorObject.loaded_config_file and os.path.exists(default_config_file):
+        print('config.pando file found, autoloading settings.')
+        RedirectorObject.autoload_config(default_config_file)
 
     choice = typing_filter.launch(RedirectorObject.get_options(), RedirectorObject.get_descriptions())
 

--- a/point.py
+++ b/point.py
@@ -1,0 +1,45 @@
+class Point(object):
+    """
+    Object for manipulating and sequencing images taken on PPS route.
+    """
+
+    def __init__(self, timestamp, fpath: str, slate, im, dng: str):
+
+        self.timestamp = timestamp
+        """Timestamp corresponding to image."""
+        self.fpath = fpath
+        """Folderpath to JPG version of image."""
+        self.dng = dng
+        """Folderpath to DNG version of image."""
+        self.slate = slate
+        """Open or end slate or None."""
+        self.im = im
+        """Image contents."""
+        self.tag = self.fpath.split('/')[-1].split('.')[0]
+        """Tag containing information assigned by Friends of Pando."""
+        self.timestamp_old = timestamp
+        """Backup version of timestamp to preserve."""
+
+    def __sub__(self, other):
+        """
+        Overwrite subtraction method to perform timestamp subtraction
+        **Args**:
+        * other (Point): additional Point object to perform delta.
+        **Returns**:
+        * delta (float): time delta between two Point objects in seconds.
+        """
+
+        diff = self.timestamp - other.timestamp
+        return diff.seconds
+
+    @staticmethod
+    def get_tag(path: str):
+        """
+        Extract tag containing information assigned by Friends of Pando.
+        **Args**:
+        * path (str): filepath to image.
+        **Returns**:
+        * tag (str): tag of image.
+        """
+
+        return path.split('/')[-1].split('.')[0]


### PR DESCRIPTION
This PR adds checks for edge cases that could potentially raise IndexErrors, auto loads the config if it exists, and clarifies some documentation.

Changes
* Update `statistical_sequence` to populate `first_half_bin` or `second_half_bin` if either are empty
* Check that the number of images match in both jpg and dng folders
* Check and warn if any images get dropped during sequencing
* Checks and automatically loads a configuration file on startup
* Update and clarify instructions in readme